### PR TITLE
MIST-674

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,14 +171,13 @@ func (m *MultiRequest) RemoveRequest(req *acomm.Request)
 ```
 RemoveRequest removes a request from the MultiRequest. Useful if the send fails.
 
-#### func (*MultiRequest) Results
+#### func (*MultiRequest) Responses
 
 ```go
-func (m *MultiRequest) Results() (map[string]interface{}, map[string]error)
+func (m *MultiRequest) Responses() map[string]*acomm.Response
 ```
-Results returns result and error values for all of the requests, keyed on the
-request name (as opposed to request id). Blocks until all requests are accounted
-for.
+Results returns responses for all of the requests, keyed on the request name (as
+opposed to request id). Blocks until all requests are accounted for.
 
 #### type Provider
 
@@ -270,14 +269,14 @@ NewSimple creates a new instance of Simple.
 #### func (*Simple) CPUInfo
 
 ```go
-func (s *Simple) CPUInfo(args map[string]interface{}) (interface{}, error)
+func (s *Simple) CPUInfo(req *acomm.Request) (interface{}, error)
 ```
 CPUInfo is a task handler to retrieve information about CPUs.
 
 #### func (*Simple) DiskInfo
 
 ```go
-func (s *Simple) DiskInfo(args map[string]interface{}) (interface{}, error)
+func (s *Simple) DiskInfo(req *acomm.Request) (interface{}, error)
 ```
 DiskInfo is a task handler to retrieve information about disks.
 
@@ -291,7 +290,7 @@ RegisterTasks registers all of Simple's task handlers with the server.
 #### func (*Simple) SystemStatus
 
 ```go
-func (s *Simple) SystemStatus(args map[string]interface{}) (interface{}, error)
+func (s *Simple) SystemStatus(req *acomm.Request) (interface{}, error)
 ```
 SystemStatus is a task handler to retrieve info look up and return system
 information. It depends on and makes requests for several other tasks.
@@ -320,7 +319,7 @@ SystemStatusResult is the result data for the SystemStatus handler.
 #### type TaskHandler
 
 ```go
-type TaskHandler func(map[string]interface{}) (interface{}, error)
+type TaskHandler func(*acomm.Request) (interface{}, error)
 ```
 
 TaskHandler if the request handler function for a particular task. It should

--- a/cmd/provider-simple/config.json
+++ b/cmd/provider-simple/config.json
@@ -1,3 +1,3 @@
 {
-    "coordinator_url": "unix://foo"
+    "coordinator_url": "unix:///tmp/mistify/coordinator/coordinator.sock"
 }

--- a/cmd/test-server/main.go
+++ b/cmd/test-server/main.go
@@ -8,7 +8,7 @@ import (
 )
 
 func main() {
-	l := acomm.NewUnixListener("foo")
+	l := acomm.NewUnixListener("/tmp/mistify/output.sock")
 	fmt.Println("URL:", l.URL())
 	if err := l.Start(); err != nil {
 		fmt.Println(err)

--- a/multireq.go
+++ b/multireq.go
@@ -50,30 +50,18 @@ func (m *MultiRequest) responseHandler(req *acomm.Request, resp *acomm.Response)
 	m.responses <- resp
 }
 
-// Results returns result and error values for all of the requests, keyed on the request name
+// Results returns responses for all of the requests, keyed on the request name
 // (as opposed to request id). Blocks until all requests are accounted for.
-func (m *MultiRequest) Results() (map[string]interface{}, map[string]error) {
-	results := make(map[string]interface{})
-	errs := make(map[string]error)
+func (m *MultiRequest) Responses() map[string]*acomm.Response {
+	results := make(map[string]*acomm.Response)
 
 	m.respWG.Wait()
 
 	close(m.responses)
 	for resp := range m.responses {
 		name := m.idsToNames[resp.ID]
-		if resp.Error != nil {
-			errs[name] = resp.Error
-		} else {
-			results[name] = resp.Result
-		}
+		results[name] = resp
 	}
 
-	if len(results) == 0 {
-		results = nil
-	}
-	if len(errs) == 0 {
-		errs = nil
-	}
-
-	return results, errs
+	return results
 }

--- a/simple.go
+++ b/simple.go
@@ -69,20 +69,23 @@ func (s *Simple) RegisterTasks(server *Server) {
 
 // SystemStatus is a task handler to retrieve info look up and return system
 // information. It depends on and makes requests for several other tasks.
-func (s *Simple) SystemStatus(args map[string]interface{}) (interface{}, error) {
-	guestID, ok := args["guest_id"].(string)
-	if !ok || guestID == "" {
+func (s *Simple) SystemStatus(req *acomm.Request) (interface{}, error) {
+	var args SystemStatusArgs
+	if err := req.UnmarshalArgs(&args); err != nil {
+		return nil, err
+	}
+	if args.GuestID == "" {
 		return nil, errors.New("missing guest_id")
 	}
 
 	// Prepare multiple requests
 	multiRequest := NewMultiRequest(s.tracker)
 
-	cpuReq, err := acomm.NewRequest("CPUInfo", s.tracker.URL().String(), &CPUInfoArgs{GuestID: guestID}, nil, nil)
+	cpuReq, err := acomm.NewRequest("CPUInfo", s.tracker.URL().String(), &CPUInfoArgs{GuestID: args.GuestID}, nil, nil)
 	if err != nil {
 		return nil, err
 	}
-	diskReq, err := acomm.NewRequest("DiskInfo", s.tracker.URL().String(), &DiskInfoArgs{GuestID: guestID}, nil, nil)
+	diskReq, err := acomm.NewRequest("DiskInfo", s.tracker.URL().String(), &DiskInfoArgs{GuestID: args.GuestID}, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -103,26 +106,39 @@ func (s *Simple) SystemStatus(args map[string]interface{}) (interface{}, error) 
 	}
 
 	// Wait for the results
-	results, errs := multiRequest.Results()
-	if errs != nil {
-		err := errors.New("one or more status requests failed")
-		log.WithFields(log.Fields{
-			"requests": requests,
-			"errors":   errs,
-		}).Error(err)
-		return nil, err
+	responses := multiRequest.Responses()
+	result := &SystemStatusResult{}
+
+	if resp, ok := responses["CPUInfo"]; ok {
+		if err := resp.UnmarshalResult(&(result.CPUs)); err != nil {
+			log.WithFields(log.Fields{
+				"name":  "CPUInfo",
+				"resp":  resp,
+				"error": err,
+			}).Error("failed to unarshal result")
+		}
 	}
 
-	result := &SystemStatusResult{
-		CPUs:  results["CPUInfo"].(CPUInfoResult),
-		Disks: results["DiskInfo"].(DiskInfoResult),
+	if resp, ok := responses["DiskInfo"]; ok {
+		if err := resp.UnmarshalResult(&(result.Disks)); err != nil {
+			log.WithFields(log.Fields{
+				"name":  "DiskInfo",
+				"resp":  resp,
+				"error": err,
+			}).Error("failed to unarshal result")
+		}
 	}
+
 	return result, nil
 }
 
 // CPUInfo is a task handler to retrieve information about CPUs.
-func (s *Simple) CPUInfo(args map[string]interface{}) (interface{}, error) {
-	if id, ok := args["guest_id"].(string); !ok || id == "" {
+func (s *Simple) CPUInfo(req *acomm.Request) (interface{}, error) {
+	var args CPUInfoArgs
+	if err := req.UnmarshalArgs(&args); err != nil {
+		return nil, err
+	}
+	if args.GuestID == "" {
 		return nil, errors.New("missing guest_id")
 	}
 
@@ -140,8 +156,12 @@ func (s *Simple) CPUInfo(args map[string]interface{}) (interface{}, error) {
 }
 
 // DiskInfo is a task handler to retrieve information about disks.
-func (s *Simple) DiskInfo(args map[string]interface{}) (interface{}, error) {
-	if id, ok := args["guest_id"].(string); !ok || id == "" {
+func (s *Simple) DiskInfo(req *acomm.Request) (interface{}, error) {
+	var args CPUInfoArgs
+	if err := req.UnmarshalArgs(&args); err != nil {
+		return nil, err
+	}
+	if args.GuestID == "" {
 		return nil, errors.New("missing guest_id")
 	}
 

--- a/task.go
+++ b/task.go
@@ -11,7 +11,7 @@ import (
 
 // TaskHandler if the request handler function for a particular task. It should
 // return results or an error, but not both.
-type TaskHandler func(map[string]interface{}) (interface{}, error)
+type TaskHandler func(*acomm.Request) (interface{}, error)
 
 // task contains the request listener and handler for a task.
 type task struct {
@@ -103,7 +103,7 @@ func (t *task) handleRequest(req *acomm.Request) {
 	defer t.waitgroup.Done()
 
 	// Run the task-specific request handler
-	result, taskErr := t.handler(req.Args.(map[string]interface{}))
+	result, taskErr := t.handler(req)
 
 	// Note: The acomm calls log the error already, but we want to have a log
 	// of the request and response data as well.


### PR DESCRIPTION
Change the task handler signature to expose the request object to the handlers. Similarly, change multireq to return the response objects. This allows the task handlers to unmarshal args and results into appropriate structs for use.

Also use the new SendConnData method, which takes care of adding the payload size header.
